### PR TITLE
adjust to requirements "change vote" etc.

### DIFF
--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -20,6 +20,7 @@ contract SimpleVote {
     function vote(int8 _vote) public returns (bool) {
         require(block.timestamp < 1557921600, "Voting is over at May 15 2019 at 12:00:00 AM CEST");
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
+        hasVoted[msg.sender] = true;
         getVote[msg.sender] = _vote;
         if(hasVoted[msg.sender] == false) {
             voters.push(msg.sender);

--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -2,10 +2,8 @@ pragma solidity ^0.5.0;
 
 contract SimpleVote {
     
-    // simply iterate over arrays, with totalVotes - 1 as an index
+    // simply iterate over arrays, with totalVotes - 0 as an index
     address[] public voters;
-    //int8[] public votes;
-    int256 public totalVotes;
     int8 public maxVoteValue;
     
     mapping (address=> int8) public getVote;
@@ -15,13 +13,16 @@ contract SimpleVote {
         maxVoteValue = _maxVoteValue;
     }
     
+    function totalVotes() view public returns (uint) {
+        return voters.length;
+    }
+    
     function vote(int8 _vote) public returns (bool) {
+        require(block.timestamp < 1557921600, "Voting is over at May 15 2019 at 12:00:00 AM CEST");
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
         getVote[msg.sender] = _vote;
         if(hasVoted[msg.sender] == false) {
-            hasVoted[msg.sender] == true
             voters.push(msg.sender);
-            totalVotes++;
         }
     }
 }

--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -19,6 +19,7 @@ contract SimpleVote {
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
         getVote[msg.sender] = _vote;
         if(hasVoted[msg.sender] == false) {
+            hasVoted[msg.sender] == true
             voters.push(msg.sender);
             totalVotes++;
         }

--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -4,24 +4,23 @@ contract SimpleVote {
     
     // simply iterate over arrays, with totalVotes - 1 as an index
     address[] public voters;
-    int8[] public votes;
+    //int8[] public votes;
     int256 public totalVotes;
     int8 public maxVoteValue;
     
     mapping (address=> int8) public getVote;
+    mapping (address=> bool) public hasVoted;
 
     constructor (int8 _maxVoteValue) public {
         maxVoteValue = _maxVoteValue;
     }
     
     function vote(int8 _vote) public returns (bool) {
-        // TODO: Uncomment next line in production, testing is easier like this now. It's prohibiting users from votig multiple times.
-        //require(getVote[msg.sender] == 0, "Sender has voted already");
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
         getVote[msg.sender] = _vote;
-        voters.push(msg.sender);
-        votes.push(_vote);
-        totalVotes++;
+        if(hasVoted[msg.sender] == false) {
+            voters.push(msg.sender);
+            totalVotes++;
+        }
     }
-    
 }

--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -20,10 +20,11 @@ contract SimpleVote {
     function vote(int8 _vote) public returns (bool) {
         require(block.timestamp < 1557921600, "Voting is over at May 15 2019 at 12:00:00 AM CEST");
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
-        hasVoted[msg.sender] = true;
         getVote[msg.sender] = _vote;
         if(hasVoted[msg.sender] == false) {
             voters.push(msg.sender);
+            hasVoted[msg.sender] = true;
+
         }
     }
 }

--- a/eth-voting-vue/contracts/SimpleVote.sol
+++ b/eth-voting-vue/contracts/SimpleVote.sol
@@ -18,7 +18,7 @@ contract SimpleVote {
     }
     
     function vote(int8 _vote) public returns (bool) {
-        require(block.timestamp < 1557921600, "Voting is over at May 15 2019 at 12:00:00 AM CEST");
+        require(block.timestamp < 1557914400, "Voting is over at May 15 2019 at 12:00:00 AM CEST");
         require(_vote <= maxVoteValue, "Voted for value higher than allowed");
         getVote[msg.sender] = _vote;
         if(hasVoted[msg.sender] == false) {


### PR DESCRIPTION
1. add a second mapping to check whether user already voted. this cannot be checked by querying the "getVote" mapping, as voting option 0 is now also allowed.

2. changing your vote is now allowed

3. no information about point of time when votes are to be counted. if clearly communicated, we can just count the votes at certain blockheight.

did I miss anything?